### PR TITLE
"Scope" instead of "Name" in authorization table

### DIFF
--- a/docs/api-spec-generated/security.md
+++ b/docs/api-spec-generated/security.md
@@ -16,7 +16,7 @@ scopes in the future such as limiting access to particular event types and strea
 *Token URL* : https://auth.example.com/oauth2/tokeninfo
 
 
-|Name|Description|
+|Scope|Description|
 |---|---|
 |nakadi.config.write|Grants access for changing Nakadi configuration.|
 |nakadi.event_type.write|Grants access for applications to define and update EventTypes.|


### PR DESCRIPTION
Based on https://github.com/zalando-incubator/tarbela I think http://zalando.github.io/nakadi-manual/docs/api-spec-generated/security.html should have "Scope" instead of "Name"

It is important to use the same terminology, to make collaborating with / setting up other projects easier. My point in question is stups-tokens, where this simple word was misleading me.
