### PR TITLE
Remove the api reference generation from the build step.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "docs:prepare": "gitbook install",
-    "docs:build": "npm run docs:prepare && npm run docs:genapi && rm -rf _book && gitbook build && rm -rf _book/bin",
+    "docs:build": "npm run docs:prepare && rm -rf _book && gitbook build && rm -rf _book/bin",
     "docs:watch": "npm run docs:prepare && gitbook serve",
     "docs:publish": "npm run docs:build && cd _book && git init && git commit --allow-empty -m 'Update docs' && git checkout -b gh-pages && git add . && git commit -am 'Update docs' && git push https://$GH_PAGES_TOKEN@github.com/zalando/nakadi-manual gh-pages --force",
     "docs:genapi": "java -cp 'bin/s2m.jar:bin/s2m-extension-commons.jar:bin/s2m-import-files-ext.jar' io.github.swagger2markup.cli.Application convert -c ./bin/s2m-config.properties -d ./docs/api-spec-generated -i ./docs/api-spec-oai/nakadi-oai-current.yaml"


### PR DESCRIPTION
Avoids losing the custom change in #13 until the table name for
the security section can be customized. 

The problem with this is going to be you have to remember to build 
the updated docs locally when the yaml file is updated; that's going 
to get in the way of building against the main project's yaml file, so 
this needs to be a temporary workaround to support #13.
