### PR TITLE
ARUHA-723 Support multiple ETs in subscriptions

### DIFF
--- a/docs/using/consuming-events-hila.md
+++ b/docs/using/consuming-events-hila.md
@@ -6,7 +6,7 @@ to avoid managing stream state locally.
 
 The typical workflow when using subscriptions is:
 
-1. Create a Subscription specifying the event-types\* you want to read.
+1. Create a Subscription specifying the event-types you want to read.
 
 1. Start reading batches of events from the subscription. 
 

--- a/docs/using/consuming-events-hila.md
+++ b/docs/using/consuming-events-hila.md
@@ -12,8 +12,6 @@ The typical workflow when using subscriptions is:
 
 1. Commit the cursors found in the event batches back to Nakadi, which will store the offsets. 
 
-_\* Note: the API signature supports subscribing to multiple event types with a single subscription._
-
 
 If the connection is closed, and later restarted, clients will get events from 
 the point of your last cursor commit. If you need more than one client for your 

--- a/docs/using/consuming-events-hila.md
+++ b/docs/using/consuming-events-hila.md
@@ -12,7 +12,7 @@ The typical workflow when using subscriptions is:
 
 1. Commit the cursors found in the event batches back to Nakadi, which will store the offsets. 
 
-_\* Note: the API signature can support subscribing to multiple event types with a single subscription, but this is not implemented yet; it's planned to be enabled soon._
+_\* Note: the API signature supports subscribing to multiple event types with a single subscription._
 
 
 If the connection is closed, and later restarted, clients will get events from 


### PR DESCRIPTION
https://techjira.zalando.net/browse/ARUHA-723

The README (and likely the manual) state that only 1 event type can be used per subscription.
This is no longer the case.