### PR TITLE
Tarbela is deprecated

### DIFF
--- a/docs/using/clients.md
+++ b/docs/using/clients.md
@@ -7,7 +7,6 @@ Nakadi does not ship with a client, but there are some open source clients avail
 | Nakadi Klients  | Scala & Java | https://github.com/zalando/nakadi-klients |
 | Reactive Nakadi | Scala/Akka   | https://github.com/zalando/reactive-nakadi |
 | Fahrschein      | Java         | https://github.com/zalando-incubator/fahrschein |
-| Tarbela         | Java         | https://github.com/zalando-incubator/tarbela |
 | Straw           | Java         | https://github.com/zalando-incubator/straw |
 
 We'll add more clients to this section as they appear. Nakadi doesn't support these clients; issues and pull requests should be filed with the client project.


### PR DESCRIPTION
Tarbela is deprecated and was just removed from public Github (it still is in Github Enterprise, but we won't link that here).